### PR TITLE
Add AGENTS.md with Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Services overview
+
+| Service | Command | Port | Notes |
+|---------|---------|------|-------|
+| Infrastructure (Redis, Postgres, Qdrant) | `docker compose -f docker-compose.dev.yml up -d` | 6379, 5433, 6333 | Must be running before backend starts |
+| Backend (FastAPI) | `uvicorn backend.main:app --host 0.0.0.0 --port 8787` | 8787 | Health: `GET /api/health` |
+| Frontend (Vite) | `cd frontend && npm run dev` | 5173 | Proxies `/api` and `/ws` to backend |
+
+### Non-obvious caveats
+
+- **PATH**: Python scripts (`uvicorn`, `pytest`, `pyright`) install to `/home/ubuntu/.local/bin`. Ensure this is on PATH (`export PATH="/home/ubuntu/.local/bin:$PATH"`).
+- **uvloop required**: The `atlas` package imports `uvloop` at the top level (`atlas/shared/loop.py`). It is not listed in `pyproject.toml` dependencies — install it with `pip install uvloop`.
+- **Docker nested container workaround**: The cloud VM runs inside a container. Docker requires `fuse-overlayfs` storage driver and `iptables-legacy`. See the daemon config at `/etc/docker/daemon.json`.
+- **Binance WebSocket 451**: The backend's Coinbase Premium service will log repeated 451 errors for the Binance WebSocket — this is expected in cloud environments without direct exchange access and does not affect health.
+- **fakeredis fallback**: If Redis is unavailable, the backend falls back to in-memory `fakeredis`. Many features degrade but the app still starts.
+- **Postgres port 5433**: Docker maps Postgres to host port 5433 (not 5432) to avoid conflicts.
+- **Migrations**: Run `python3 -m atlas.rag.migrations.run_migrations` after infrastructure is up. Idempotent — safe to rerun.
+
+### Running tests
+
+- **Python**: `pytest` from repo root. Expect ~1461 passing tests. Collection errors for GNN tests require `torch-geometric` (optional `[gnn]` extra — heavy dependency, not required for core flow).
+- **Frontend**: `cd frontend && npx vitest run` — 196 tests, all pass.
+- **Linting**: `pyright backend/` (Python type checking), `cd frontend && npx eslint src/` (JS/TS linting).
+
+### Environment variables
+
+Copy `.env.example` → `.env` at repo root. The defaults match `docker-compose.dev.yml` ports and are sufficient for local development without exchange writes. No real API keys are needed for basic health/dashboard functionality.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific instructions for future cloud agents working in this repository.

## What's included

- Service overview table (Docker infrastructure, FastAPI backend, Vite frontend)
- Non-obvious caveats discovered during setup:
  - PATH configuration for pip-installed scripts
  - `uvloop` dependency not listed in `pyproject.toml` but required at import time
  - Docker nested container workarounds (fuse-overlayfs, iptables-legacy)
  - Binance WebSocket 451 errors in cloud environments (expected/non-blocking)
  - Postgres mapped to port 5433 (not default 5432)
- Test running instructions with expected pass counts
- Environment variable configuration guidance

## Evidence of working environment

[polaris-dashboard-demo.mp4](https://cursor.com/agents/bc-aef6c8eb-8444-47c3-a5ae-131859373be8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpolaris-dashboard-demo.mp4)

Dashboard loads successfully showing 8-asset live horizon with BTC, ETH, SOL, and other assets.

[POLARIS Dashboard Main View](https://cursor.com/agents/bc-aef6c8eb-8444-47c3-a5ae-131859373be8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_main_view.webp)
[Agents and MARL Deliberation Page](https://cursor.com/agents/bc-aef6c8eb-8444-47c3-a5ae-131859373be8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagents_marl_page.webp)

### Test results
- Python: 1461 passing tests (pytest)
- Frontend: 196 passing tests (vitest)
- Backend health: `{"status": "healthy", "startup_degraded": false}`
- All infrastructure services healthy (Redis, Postgres, Qdrant)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aef6c8eb-8444-47c3-a5ae-131859373be8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aef6c8eb-8444-47c3-a5ae-131859373be8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

